### PR TITLE
Adding support for configure Batch Span Processor (BSP)

### DIFF
--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -131,6 +131,10 @@
 
   "opentelemetry.filtered.mediator.names": "synapse_properties.'oltp.filtered.mediator.names'",
   "opentelemetry.custom.span.header.tags": "synapse_properties.'oltp.custom.span.header.tags'",
+  "opentelemetry.bsp.max.queue.size": "synapse_properties.'opentelemetry.bsp.max.queue.size'",
+  "opentelemetry.bsp.max.export.batch.size": "synapse_properties.'opentelemetry.bsp.max.export.batch.size'",
+  "opentelemetry.bsp.schedule.delay.millis": "synapse_properties.'opentelemetry.bsp.schedule.delay.millis'",
+  "opentelemetry.bsp.export.timeout.millis": "synapse_properties.'opentelemetry.bsp.export.timeout.millis'",
 
   "transport.http.socket_timeout": "passthru_properties.'http.socket.timeout'",
   "transport.http.block_service_list": "passthru_properties.'http.block_service_list'",


### PR DESCRIPTION
Adding support for configuring the Batch Span Processor (BSP) to handle high-volume trace scenarios.

This pull request adds new key mappings for OpenTelemetry batch span processor (BSP) configuration options in the `key-mappings.json` file. These mappings allow the configuration tool to correctly map BSP-related properties from `synapse_properties`.

OpenTelemetry BSP configuration mappings:

* Added mappings for `opentelemetry.bsp.max.queue.size`, `opentelemetry.bsp.max.export.batch.size`, `opentelemetry.bsp.schedule.delay.millis`, and `opentelemetry.bsp.export.timeout.millis` to their corresponding `synapse_properties` keys in `key-mappings.json`.