### PR TITLE
Consolidate and fix JaCoCo coverage infrastructure

### DIFF
--- a/components/crypto-service/org.wso2.micro.integrator.crypto.impl/pom.xml
+++ b/components/crypto-service/org.wso2.micro.integrator.crypto.impl/pom.xml
@@ -74,35 +74,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-crypto-service.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/components/crypto-service/org.wso2.micro.integrator.crypto.provider/pom.xml
+++ b/components/crypto-service/org.wso2.micro.integrator.crypto.provider/pom.xml
@@ -71,35 +71,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-crypto-provider.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
@@ -293,7 +293,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>true</inherited>
                 <configuration>
-                    <forkMode>pertest</forkMode>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                     <argLine>-Xms512m -Xmx1024m @{argLine}</argLine>
                     <testFailureIgnore>false</testFailureIgnore>
                     <includes>

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
@@ -93,12 +93,6 @@
             <artifactId>org.wso2.micro.integrator.mediation.ntask</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-core</artifactId>
             <scope>test</scope>
@@ -201,7 +195,6 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <jacoco-agent.destfile>target/coverage-reports/jacoco-unit-commons.exec</jacoco-agent.destfile>
                         <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog
                         </org.apache.commons.logging.Log>
                         <org.apache.commons.logging.simplelog.defaultlog>error
@@ -211,35 +204,6 @@
                         <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-inbound-endpoint.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/pom.xml
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/pom.xml
@@ -109,35 +109,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-cache-mediator.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/pom.xml
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/pom.xml
@@ -60,35 +60,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-registry.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/org.wso2.micro.integrator.bootstrap/pom.xml
+++ b/components/org.wso2.micro.integrator.bootstrap/pom.xml
@@ -50,37 +50,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-bootstrap.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/components/org.wso2.micro.integrator.core/pom.xml
+++ b/components/org.wso2.micro.integrator.core/pom.xml
@@ -90,35 +90,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-micro-integrator-core.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
@@ -94,35 +94,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-management-apis.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/components/org.wso2.micro.integrator.initializer/pom.xml
+++ b/components/org.wso2.micro.integrator.initializer/pom.xml
@@ -186,35 +186,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-initializer.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
@@ -80,35 +80,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-instrument</id>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>target/coverage-reports/jacoco-unit-ndatasource.rdbms.exec</dataFile>
-                            <outputDirectory>target/coverage-reports/site</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/components/org.wso2.micro.integrator.osgi.security/pom.xml
+++ b/components/org.wso2.micro.integrator.osgi.security/pom.xml
@@ -79,8 +79,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>true</inherited>
                 <configuration>
-                    <forkMode>pertest</forkMode>
-                    <argLine>-enableassertions</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <argLine>-enableassertions @{argLine}</argLine>
                     <testFailureIgnore>false</testFailureIgnore>
                     <excludes>
                         <exclude>**/BaseTestCase.java</exclude>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -63,4 +63,29 @@
         <module>org.wso2.micro.integrator.osgi.security</module>
         <module>org.wso2.carbon.securevault</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2246,7 +2246,7 @@
         <docker.maven.plugin.version>1.0.0</docker.maven.plugin.version>
         <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
-        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <testng.version>6.11</testng.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
@@ -2635,6 +2635,86 @@
                     <target>21</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.maven.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <!-- Merge all component exec files into one -->
+                    <execution>
+                        <id>merge-component-coverage</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.basedir}/components</directory>
+                                    <includes>
+                                        <include>**/target/jacoco.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- JaCoCo Ant task: aggregate HTML/CSV/XML report + terminal coverage line.
+                 Must be declared AFTER jacoco plugin so merge runs first in verify phase. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <inherited>false</inherited>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.maven.plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>jacoco-aggregate-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target xmlns:jacoco="antlib:org.jacoco.ant">
+                                <taskdef uri="antlib:org.jacoco.ant"
+                                         resource="org/jacoco/ant/antlib.xml"
+                                         classpathref="maven.plugin.classpath"/>
+                                <jacoco:report>
+                                    <executiondata>
+                                        <file file="${project.build.directory}/jacoco-merged.exec"/>
+                                    </executiondata>
+                                    <structure name="WSO2 Micro Integrator">
+                                        <classfiles>
+                                            <fileset dir="${project.basedir}/components">
+                                                <include name="**/target/classes/**/*.class"/>
+                                            </fileset>
+                                        </classfiles>
+                                    </structure>
+                                    <html destdir="${project.build.directory}/site/jacoco-aggregate"/>
+                                    <csv destfile="${project.build.directory}/site/jacoco-aggregate/jacoco.csv"/>
+                                    <xml destfile="${project.build.directory}/site/jacoco-aggregate/jacoco.xml"/>
+                                </jacoco:report>
+                                <exec executable="awk" outputproperty="jacoco.line.coverage" failonerror="false">
+                                    <arg value="-F,"/>
+                                    <arg value="NR&gt;1{m+=$8; c+=$9} END{printf &quot;Line coverage: %.1f%% (%d / %d lines covered)&quot;, c/(c+m)*100, c, c+m}"/>
+                                    <arg value="${project.build.directory}/site/jacoco-aggregate/jacoco.csv"/>
+                                </exec>
+                                <echo>&#10;========================================</echo>
+                                <echo>${jacoco.line.coverage}</echo>
+                                <echo>========================================&#10;</echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -2706,6 +2786,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
+                    <configuration>
+                        <argLine>@{argLine}
+                            --add-opens java.base/java.lang=ALL-UNNAMED
+                            --add-opens java.base/java.util=ALL-UNNAMED
+                            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                            -XX:+EnableDynamicAgentLoading
+                        </argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- Bumped maven-surefire-plugin from 2.22.2 to 3.2.5 
- Removed per-module JaCoCo plugin declarations from all component modules that had custom exec file paths
- Added prepare-agent + report executions to components/pom.xml so all components inherit a consistent setup writing to the standard target/jacoco.exec
- Added jacoco:merge at root pom.xml to collect all components/**/target/jacoco.exec into a single target/jacoco-merged.exec
- Added maven-antrun-plugin + org.jacoco.ant at root pom.xml to generate an aggregate HTML/CSV/XML report at target/site/jacoco-aggregate/
- Added awk execution after the Ant report task to print a one-line coverage summary to the terminal at the end of the verify phase
- Replaced the removed forkMode parameter with forkCount + reuseForks in the modules that used it 
- Switched to @{argLine} late-binding in Surefire config so the JaCoCo agent argument is picked up on forked JVMs