### PR TITLE
 Fix last .env variable being dropped when the file has no trailing newline

### DIFF
--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -129,8 +129,10 @@ export_env_file() {
     return 1  # Return with an error status
   fi
 
-  # Read the .env file and export each variable to the environment
-  while IFS='=' read -r key value; do
+  # Read the .env file and export each variable to the environment.
+  # The "|| [ -n "$key" ]" handles a final line without a trailing newline,
+  # for which "read" returns a non-zero status even though it sets the variables.
+  while IFS='=' read -r key value || [ -n "$key" ]; do
       # Ignore lines starting with '#' (comments) or empty lines
       case "$key" in
           \#*|"")


### PR DESCRIPTION
## Purpose

When an `.env` file is passed via `--env-file=`, the value of the **last** environment
variable is silently dropped if the file has **no trailing newline**.

In `export_env_file()` (`distribution/src/scripts/micro-integrator.sh`), the loop
`while IFS='=' read -r key value; do` relies on `read` returning exit status 0. On the
final line of a file with no trailing newline, `read` still populates `key`/`value` but
returns a non-zero status at EOF, so the loop body never runs for that last line and the
variable is never exported.

Resolves wso2/micro-integrator#4234

## Goals
Ensure the last variable in an `.env` file is exported regardless of whether the file
ends with a trailing newline.

## Approach
Added `|| [ -n "$key" ]` to the `while read` loop condition so the final line is still
processed when `read` returns non-zero at EOF but has already set the variables:

```sh
while IFS='=' read -r key value || [ -n "$key" ]; do