### PR TITLE
Log heartbeat failures at warn level instead of debug

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
@@ -114,7 +114,7 @@ public class HeartBeatComponent {
                     log.debug("Error occurred while sending the heartbeat.");
                 }
             } catch (Exception e) {
-                log.debug("Error occurred while processing the heartbeat.", e);
+                log.warn("Error occurred while processing the heartbeat.", e);
             }
         };
         scheduledExecutorService.scheduleAtFixedRate(runnableTask, 1, interval, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary

Fixes #4913.

`HeartBeatComponent.invokeHeartbeatExecutorService()` catches all exceptions from the heartbeat HTTP call to the dashboard/ICP and logs them at `debug` level only. Since debug logging is typically disabled in production, heartbeat failures go completely unnoticed.

## Change

Changed the log level in that catch block from `debug` to `warn`, so failures are visible in production logs by default without needing debug logging enabled. The exception message and full stack trace are still logged, so no diagnostic detail is lost.

This is a minimal, scoped version of the reporter's suggestion (they also proposed a configurable threshold for repeated failures), keeping the change small and focused on the core visibility problem they raised.

## Test plan

- [x] `mvn compile` on `components/org.wso2.micro.integrator.initializer` succeeds with this change (BUILD SUCCESS).