### PR TITLE
Allow advertising MI management endpoint behind a reverse proxy

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
@@ -17,8 +17,6 @@ public class Constants {
 
     // New ICP Configuration
     public static final String ICP_API_DEFAULT_HOST = "localhost";
-    public static final int ICP_API_DEFAULT_PORT = 9164;
-    public static final String PORT_OFFSET = "server.offset";
     public static final String HOSTNAME = "server.hostname";
     public static final String ICP_CONFIG_URL = "icp_config.icp_url";
     public static final String ICP_CONFIG_ENVIRONMENT = "icp_config.environment";
@@ -28,6 +26,7 @@ public class Constants {
     public static final String ICP_CONFIG_ENABLED = "icp_config.enabled";
     public static final String  ICP_CONFIG_HEARTBEAT_INTERVAL = "icp_config.heartbeat_interval";
     public static final String ICP_CONFIG_SSL_VERIFY = "icp_config.ssl_verify";
+    public static final String ICP_CONFIG_MANAGEMENT_URL = "icp_config.management_url";
 
     // JWT Configuration
     public static final String ICP_JWT_ISSUER = "icp_config.jwt_issuer";

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
@@ -28,6 +28,8 @@ public class Constants {
     public static final String ICP_CONFIG_ENABLED = "icp_config.enabled";
     public static final String  ICP_CONFIG_HEARTBEAT_INTERVAL = "icp_config.heartbeat_interval";
     public static final String ICP_CONFIG_SSL_VERIFY = "icp_config.ssl_verify";
+    public static final String ICP_CONFIG_MANAGEMENT_HOSTNAME = "icp_config.management_hostname";
+    public static final String ICP_CONFIG_MANAGEMENT_PORT = "icp_config.management_port";
 
     // JWT Configuration
     public static final String ICP_JWT_ISSUER = "icp_config.jwt_issuer";

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
@@ -56,6 +56,7 @@ import org.apache.synapse.endpoints.HTTPEndpoint;
 import org.apache.synapse.endpoints.WSDLEndpoint;
 import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.application.deployer.CarbonApplication;
 import org.wso2.micro.application.deployer.config.Artifact;
@@ -141,6 +142,15 @@ public class ICPHeartBeatComponent {
             return;
         }
 
+        ManagementEndpoint managementEndpoint;
+        try {
+            managementEndpoint = resolveManagementEndpoint();
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid config for '" + ICP_CONFIG_MANAGEMENT_URL + "': " + e.getMessage()
+                    + " ICP heartbeat will not be started.");
+            return;
+        }
+
         // Fail fast if JWT secret/token generation is unavailable
         try {
             generateOrGetCachedJwtToken();
@@ -164,7 +174,7 @@ public class ICPHeartBeatComponent {
         });
         Runnable runnableTask = () -> {
             try {
-                sendDeltaHeartbeat(icpUrl);
+                sendDeltaHeartbeat(icpUrl, managementEndpoint);
             } catch (Exception e) {
                 log.error("Error occurred while sending delta heartbeat to ICP.", e);
             }
@@ -214,10 +224,10 @@ public class ICPHeartBeatComponent {
      * If ICP detects a hash mismatch, it will respond with
      * fullHeartbeatRequired=true.
      */
-    private static void sendDeltaHeartbeat(String icpUrl) {
+    private static void sendDeltaHeartbeat(String icpUrl, ManagementEndpoint managementEndpoint) {
         try {
             // Build full payload to calculate hash
-            JsonObject fullPayload = buildFullHeartbeatPayload(false);
+            JsonObject fullPayload = buildFullHeartbeatPayload(false, managementEndpoint);
             String currentHash = fullPayload.get(FIELD_RUNTIME_HASH).getAsString();
 
             // Build delta payload
@@ -235,7 +245,7 @@ public class ICPHeartBeatComponent {
             if (response != null && response.has("fullHeartbeatRequired")
                     && response.get("fullHeartbeatRequired").getAsBoolean()) {
                 log.info("ICP requested full heartbeat. Sending full heartbeat with all artifacts.");
-                sendFullHeartbeat(icpUrl);
+                sendFullHeartbeat(icpUrl, managementEndpoint);
             } else if (response != null && response.has("acknowledged")
                     && response.get("acknowledged").getAsBoolean()) {
                 if (log.isDebugEnabled()) {
@@ -250,9 +260,9 @@ public class ICPHeartBeatComponent {
     /**
      * Sends a full heartbeat to ICP with all artifact metadata.
      */
-    private static void sendFullHeartbeat(String icpUrl) {
+    private static void sendFullHeartbeat(String icpUrl, ManagementEndpoint managementEndpoint) {
         try {
-            JsonObject fullPayload = buildFullHeartbeatPayload(true);
+            JsonObject fullPayload = buildFullHeartbeatPayload(true, managementEndpoint);
             String fullEndpoint = icpUrl + ICP_HEARTBEAT_ENDPOINT;
 
             JsonObject response = sendHeartbeatRequest(fullEndpoint, fullPayload);
@@ -332,7 +342,8 @@ public class ICPHeartBeatComponent {
     /**
      * Builds the full heartbeat payload with all artifact metadata.
      */
-    private static JsonObject buildFullHeartbeatPayload(boolean includeTimestamp) throws IOException {
+    private static JsonObject buildFullHeartbeatPayload(boolean includeTimestamp,
+                                                         ManagementEndpoint managementEndpoint) throws IOException {
         JsonObject payload = new JsonObject();
         payload.addProperty("heartbeatVersion", HEARTBEAT_VERSION);
         payload.addProperty(Constants.RUNTIME_ID, getRuntimeId());
@@ -346,15 +357,8 @@ public class ICPHeartBeatComponent {
         payload.addProperty("project", getProject());
         payload.addProperty("component", getComponent());
         payload.addProperty("version", getMicroIntegratorVersion());
-        // Optional management endpoint details (hostname and port)
-        String runtimeHost = getICPApiHostname();
-        String runtimePort = getICPAPIPort();
-        if (!StringUtils.isEmpty(runtimeHost)) {
-            payload.addProperty("runtimeHostname", runtimeHost);
-        }
-        if (!StringUtils.isEmpty(runtimePort)) {
-            payload.addProperty("runtimePort", runtimePort);
-        }
+        payload.addProperty("runtimeHostname", managementEndpoint.getHostname());
+        payload.addProperty("runtimePort", String.valueOf(managementEndpoint.getPort()));
 
         // Node information
         JsonObject nodeInfo = new JsonObject();
@@ -395,52 +399,21 @@ public class ICPHeartBeatComponent {
         return payload;
     }
 
-    private static String getICPApiHostname() {
-        try {
-            Object configured = configs.get(HOSTNAME);
-            if (configured != null && !StringUtils.isEmpty(configured.toString())) {
-                return configured.toString();
-            }
-            String localIp = System.getProperty("carbon.local.ip");
-            if (!StringUtils.isEmpty(localIp)) {
-                return localIp;
-            }
-        } catch (Exception ignored) {
-            // fall through to default
+    private static ManagementEndpoint resolveManagementEndpoint() {
+        String managementUrl = getConfigValue(ICP_CONFIG_MANAGEMENT_URL);
+        if (managementUrl != null) {
+            return ManagementEndpoint.fromUrl(managementUrl);
         }
-        return ICP_API_DEFAULT_HOST;
+        return new ManagementEndpoint(getManagementHostname(), ConfigurationLoader.getInternalInboundHttpsPort());
     }
 
-    /**
-     * Resolves the ICP API port to report in the ICP heartbeat.
-     * Priority:
-     * 1) Calculated from `offset` (if provided)
-     * 2) Default ICP API port (9164)
-     */
-    private static String getICPAPIPort() {
-        try {
-            // Read offset only from dashboard config (no legacy checks)
-            int offset = 0;
-            Object offsetCfg = configs.get(PORT_OFFSET);
-            if (offsetCfg != null && !StringUtils.isEmpty(offsetCfg.toString())) {
-                try {
-                    offset = Integer.parseInt(offsetCfg.toString());
-                } catch (NumberFormatException ignored) {
-                    // keep offset = 0 if invalid
-                }
-            }
-
-            if (ICP_API_DEFAULT_PORT > 0) {
-                if (offset != 0) {
-                    int computed = ICP_API_DEFAULT_PORT - 10 + offset;
-                    return String.valueOf(computed);
-                }
-                return String.valueOf(ICP_API_DEFAULT_PORT);
-            }
-        } catch (Exception ignored) {
-            // fall through
+    private static String getManagementHostname() {
+        Object configured = configs.get(HOSTNAME);
+        if (configured != null && !StringUtils.isEmpty(configured.toString())) {
+            return configured.toString();
         }
-        return String.valueOf(ICP_API_DEFAULT_PORT);
+        String localIp = System.getProperty("carbon.local.ip");
+        return StringUtils.isEmpty(localIp) ? ICP_API_DEFAULT_HOST : localIp;
     }
 
     /**

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
@@ -397,6 +397,10 @@ public class ICPHeartBeatComponent {
 
     private static String getICPApiHostname() {
         try {
+            String managementHostname = getConfigValue(ICP_CONFIG_MANAGEMENT_HOSTNAME);
+            if (!StringUtils.isEmpty(managementHostname)) {
+                return managementHostname;
+            }
             Object configured = configs.get(HOSTNAME);
             if (configured != null && !StringUtils.isEmpty(configured.toString())) {
                 return configured.toString();
@@ -414,12 +418,16 @@ public class ICPHeartBeatComponent {
     /**
      * Resolves the ICP API port to report in the ICP heartbeat.
      * Priority:
-     * 1) Calculated from `offset` (if provided)
-     * 2) Default ICP API port (9164)
+     * 1) `icp_config.management_port` (if provided)
+     * 2) Calculated from `server.offset` (if provided)
+     * 3) Default ICP API port (9164)
      */
     private static String getICPAPIPort() {
         try {
-            // Read offset only from dashboard config (no legacy checks)
+            String managementPort = getConfigValue(ICP_CONFIG_MANAGEMENT_PORT);
+            if (!StringUtils.isEmpty(managementPort)) {
+                return managementPort;
+            }
             int offset = 0;
             Object offsetCfg = configs.get(PORT_OFFSET);
             if (offsetCfg != null && !StringUtils.isEmpty(offsetCfg.toString())) {

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ManagementEndpoint.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ManagementEndpoint.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.initializer.dashboard;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+final class ManagementEndpoint {
+
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    private final String hostname;
+    private final int port;
+
+    ManagementEndpoint(String hostname, int port) {
+        if (hostname == null || hostname.isBlank()) {
+            throw new IllegalArgumentException("URL must include a hostname.");
+        }
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("URL port must be between 1 and 65535.");
+        }
+        this.hostname = hostname;
+        this.port = port;
+    }
+
+    String getHostname() {
+        return hostname;
+    }
+
+    int getPort() {
+        return port;
+    }
+
+    static ManagementEndpoint fromUrl(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("URL must not be empty.");
+        }
+
+        URI uri;
+        try {
+            uri = new URI(value.trim());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Value must be a valid absolute URL.");
+        }
+
+        if (!"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Only HTTPS URLs are supported for the management URL.");
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank()) {
+            throw new IllegalArgumentException("URL must include a valid hostname.");
+        }
+        if (uri.getUserInfo() != null || uri.getQuery() != null || uri.getFragment() != null) {
+            throw new IllegalArgumentException("URL must not include user info, a query, or a fragment.");
+        }
+        String path = uri.getRawPath();
+        if (path != null && !path.isEmpty() && !"/".equals(path)) {
+            throw new IllegalArgumentException("The management URL must not contain a path.");
+        }
+        if (uri.getRawAuthority().endsWith(":")) {
+            throw new IllegalArgumentException("URL must include a port after ':'.");
+        }
+
+        int port = uri.getPort() == -1 ? DEFAULT_HTTPS_PORT : uri.getPort();
+        return new ManagementEndpoint(uri.getHost(), port);
+    }
+}

--- a/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/dashboard/ManagementEndpointTest.java
+++ b/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/dashboard/ManagementEndpointTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.initializer.dashboard;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for ManagementEndpoint, which parses the management URL advertised to ICP
+ * in the heartbeat payload.
+ */
+public class ManagementEndpointTest {
+
+    @Test
+    public void testFromUrl_HttpsUrlWithPort_ParsesHostnameAndPort() {
+        ManagementEndpoint endpoint = ManagementEndpoint.fromUrl("https://mi.example.com:8443");
+
+        assertEquals("Hostname should be taken from the URL", "mi.example.com", endpoint.getHostname());
+        assertEquals("Port should be taken from the URL", 8443, endpoint.getPort());
+    }
+
+    @Test
+    public void testFromUrl_HttpsUrlWithoutPort_UsesDefaultHttpsPort() {
+        ManagementEndpoint endpoint = ManagementEndpoint.fromUrl("https://mi.example.com/");
+
+        assertEquals("Hostname should be taken from the URL", "mi.example.com", endpoint.getHostname());
+        assertEquals("Port should default to the HTTPS port", 443, endpoint.getPort());
+    }
+
+    @Test
+    public void testFromUrl_UnsupportedUrlParts_ThrowsException() {
+        assertInvalid("http://mi.example.com", "HTTPS");
+        assertInvalid("https://mi.example.com/gateway", "must not contain a path");
+        assertInvalid("https://mi.example.com/%2F", "must not contain a path");
+        assertInvalid("https://user@mi.example.com", "user info");
+        assertInvalid("https://mi.example.com?region=us", "query");
+        assertInvalid("https://mi.example.com#management", "fragment");
+    }
+
+    @Test
+    public void testFromUrl_MalformedUrls_ThrowsException() {
+        assertInvalid("", "empty");
+        assertInvalid("mi.example.com:443", "HTTPS");
+        assertInvalid("https://mi.example.com:", "port");
+        assertInvalid("https://mi.example.com:65536", "between 1 and 65535");
+    }
+
+    private static void assertInvalid(String value, String expectedMessage) {
+        try {
+            ManagementEndpoint.fromUrl(value);
+            fail("Expected URL to be rejected");
+        } catch (IllegalArgumentException e) {
+            if (!e.getMessage().contains(expectedMessage)) {
+                fail("Expected error containing '" + expectedMessage + "' but got: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/distribution/src/conf/deployment.toml
+++ b/distribution/src/conf/deployment.toml
@@ -111,3 +111,7 @@ algorithm = "AES"
 
 # [dashboard_config]
 # dashboard_url = "https://localhost:9743/dashboard/api/"
+
+# [icp_config]
+# Externally reachable MI management URL advertised to ICP.
+# management_url = "https://mi.example.com:443"

--- a/distribution/src/conf/deployment.toml
+++ b/distribution/src/conf/deployment.toml
@@ -111,3 +111,9 @@ algorithm = "AES"
 
 # [dashboard_config]
 # dashboard_url = "https://localhost:9743/dashboard/api/"
+
+# [icp_config]
+# Externally reachable MI management endpoint advertised to ICP.
+# Defaults to server.hostname and the actual management port.
+# management_hostname = "mi.example.com"
+# management_port = 443


### PR DESCRIPTION
## Purpose

When MI is deployed in a different data center or network zone from ICP, a reverse proxy, ingress, or API gateway typically fronts MI. ICP must then reach the MI management API through that endpoint.

The ICP heartbeat currently advertises the management endpoint as `runtimeHostname` and `runtimePort`. These values are derived from `server.hostname` and the actual management port, so an external endpoint cannot be configured independently. Using separate hostname and port settings would also prevent future support for a different protocol or proxy context without another configuration migration.

## Goals

Let a deployment configure the externally reachable MI management URL without changing the heartbeat v1.0 format or affecting other MI configuration.

## Approach

Add one optional setting:

```toml
[icp_config]
management_url = "https://mi.example.com:443"
```

MI parses the URL once before starting the ICP heartbeat service and continues sending only the existing fields:

- `runtimeHostname = "mi.example.com"`
- `runtimePort = "443"`

Heartbeat v1.0 cannot represent protocol or context. MI therefore currently accepts only HTTPS URLs with an empty or root path. It also rejects user info, queries, fragments, invalid hosts, and invalid ports. An omitted HTTPS port resolves to `443`.

If `management_url` is invalid, MI logs an actionable error and does not start the ICP heartbeat service. MI itself continues starting, consistent with existing invalid ICP JWT configuration handling. An explicitly invalid setting is never silently ignored.

When `management_url` is absent, MI uses `server.hostname` and the effective internal HTTPS API listener port. The port comes from `ConfigurationLoader`, so it includes both a customized internal HTTPS API base port and `server.offset`. Legacy `dashboard_config.management_hostname` and `management_port` settings remain untouched.

Changes:

- `Constants`: added `ICP_CONFIG_MANAGEMENT_URL`
- `ICPHeartBeatComponent`: resolves the endpoint before scheduling heartbeats, uses the authoritative listener port when no URL is configured, and passes the endpoint into payload construction
- `ManagementEndpoint`: parses and validates the configured URL
- `ManagementEndpointTest`: covers valid URLs, default HTTPS port, and unsupported URL forms
- `distribution/src/conf/deployment.toml`: documents the optional setting

## User stories

As an integration administrator running MI separately from ICP, I can advertise the gateway endpoint through which ICP can manage MI.

## Release note

MI can now advertise an external management endpoint to ICP using the optional `icp_config.management_url` setting. Heartbeat v1.0 supports HTTPS endpoints without a proxy context.

## Documentation

Document the optional `[icp_config].management_url` setting and its current heartbeat v1.0 restrictions. The setting is also documented inline in `distribution/src/conf/deployment.toml`.

## Training

N/A

## Certification

N/A — configuration option for an existing capability.

## Marketing

N/A

## Automation tests

- `mvn -pl components/org.wso2.micro.integrator.initializer -Dtest=ManagementEndpointTest -Djacoco.skip=true clean test`
  - 4 tests, 0 failures
- `make mi`
  - Full MI reactor and distribution build successful
- `git diff --check`
  - Clean

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

The configured URL is not included in validation error logs, avoiding accidental disclosure if a user incorrectly supplies credentials.

## Samples

N/A

## Related PRs

None

## Migrations (if applicable)

None. `management_url` is optional and defaults to the existing behavior. The earlier hostname/port proposal was not released.

## Test environment

- JDK 21
- macOS 15, arm64

## Learning

ICP heartbeat v1.0 uses a closed record and reconstructs MI management URLs as HTTPS from `runtimeHostname` and `runtimePort`. Keeping a URL-shaped MI configuration now avoids a future user-facing configuration migration, while strict local validation prevents protocol or context information from being silently discarded until the heartbeat schema supports it.