### PR TITLE
Skip undeploying a synapse library still used by another deployed CApp

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -78,6 +78,7 @@ import org.wso2.micro.application.deployer.handler.AppDeploymentHandler;
 import org.wso2.micro.core.util.StringUtils;
 import org.wso2.micro.integrator.core.util.MicroIntegratorBaseUtils;
 import org.wso2.micro.integrator.initializer.ServiceBusConstants;
+import org.wso2.micro.integrator.initializer.deployment.application.deployer.CappDeployer;
 import org.wso2.micro.integrator.initializer.ServiceBusUtils;
 import org.wso2.micro.integrator.initializer.persistence.MediationPersistenceManager;
 import org.wso2.micro.integrator.initializer.utils.ConfigurationHolder;
@@ -301,9 +302,14 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                         }
                         deployer.undeploy(artifactPath);
                     } else if (SynapseAppDeployerConstants.SYNAPSE_LIBRARY_TYPE.equals(artifact.getType())){
-                        String libQName = getArtifactName(artifactPath, axisConfig);
-                        deleteImport(libQName, axisConfig);
-                        deployer.undeploy(artifactPath);
+                        if (isLibraryUsedByOtherCApps(artifact.getName(), carbonApplication)) {
+                            log.info("Skipping undeployment of synapse library '" + artifact.getName()
+                                    + "' since it is still used by another deployed Carbon Application");
+                        } else {
+                            String libQName = getArtifactName(artifactPath, axisConfig);
+                            deleteImport(libQName, axisConfig);
+                            deployer.undeploy(artifactPath);
+                        }
                     } else if (SynapseAppDeployerConstants.SEQUENCE_TYPE.equals(artifact.getType())
                                && handleMainFaultSeqUndeployment(artifact, axisConfig)) {
                         log.debug("Handling main and fault sequence un-deployment");
@@ -1361,6 +1367,36 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
 
     private String getConnectorName(String artifactName) {
         return artifactName.substring(0, artifactName.lastIndexOf("-connector"));
+    }
+
+    /**
+     * Checks whether a synapse library artifact is still declared as a dependency by another
+     * currently deployed Carbon Application, so a shared connector library is not removed while
+     * another CApp is still using it.
+     */
+    private boolean isLibraryUsedByOtherCApps(String libraryName, CarbonApplication currentApp) {
+
+        for (CarbonApplication otherApp : CappDeployer.getCarbonApps()) {
+            if (otherApp.getAppNameWithVersion().equals(currentApp.getAppNameWithVersion())) {
+                continue;
+            }
+            for (Artifact.Dependency dep : otherApp.getAppConfig().getApplicationArtifact().getDependencies()) {
+                Artifact otherArtifact = dep.getArtifact();
+                if (otherArtifact == null || !AppDeployerConstants.DEPLOYMENT_STATUS_DEPLOYED
+                        .equals(otherArtifact.getDeploymentStatus())) {
+                    continue;
+                }
+                if (SynapseAppDeployerConstants.SYNAPSE_LIBRARY_TYPE.equals(otherArtifact.getType())
+                        && libraryName.equals(otherArtifact.getName())) {
+                    return true;
+                }
+                if (SynapseAppDeployerConstants.CONNECTOR_DEPENDENCY_TYPE.equals(otherArtifact.getType())
+                        && libraryName.equals(otherArtifact.getConnector())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private String getTemplateName(String artifactPath, String name) {


### PR DESCRIPTION
## Summary

Fixes #4898.

When the same connector exists in multiple CApps, undeploying one CApp after server startup also undeploys the connector for every other CApp that still uses it.

## Root cause

A connector is packaged into a CApp as a `SYNAPSE_LIBRARY_TYPE` host library plus a `CONNECTOR_DEPENDENCY_TYPE` artifact attached to it. `undeployArtifactType()` in `SynapseAppDeployer.java` unconditionally undeployed the `SYNAPSE_LIBRARY_TYPE` artifact, which calls through to `LibraryArtifactDeployer.undeploySynapseArtifact()` in `wso2-synapse`. That method's `unLoadLibrary()` call is reference-counted (`SynapseConfiguration.getDeployedLibCount(artifactName) <= 1`), but its `removeSynapseImport()` and `removeSynapseLibrary()` calls are not, so the library's global registration is removed as soon as any one CApp referencing it undeploys, even while another CApp still depends on it.

Since the reference-counting gap itself is in `wso2-synapse`, this fix addresses it on the `product-integrator-mi` side instead.

## Change

Before undeploying a `SYNAPSE_LIBRARY_TYPE` artifact, check whether any other currently deployed CApp still declares a dependency on the same library, either directly (`SYNAPSE_LIBRARY_TYPE` with a matching name) or via a `CONNECTOR_DEPENDENCY_TYPE` artifact pointing at it (`artifact.getConnector()`). The check uses the CApp registry already tracked in `CappDeployer.getCarbonApps()`. If another deployed CApp still needs the library, the undeploy is skipped for the current CApp.

## Test plan

- [x] `mvn compile` on `components/org.wso2.micro.integrator.initializer` succeeds with this change (BUILD SUCCESS).
- [ ] I could not verify this against a live two-CApp deploy/undeploy scenario in this environment, since that requires a running MI server. Maintainer/CI verification requested: deploy two CApps sharing a connector, undeploy one, and confirm the connector still works for the remaining CApp.
