### PR TITLE
Sign the legacy dashboard registration challenge with the shared admin password

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
@@ -14,6 +14,17 @@ public class Constants {
     public static final String DASHBOARD_CONFIG_HEARTBEAT_INTERVAL = "dashboard_config.heartbeat_interval";
     public static final String DASHBOARD_CONFIG_MANAGEMENT_HOSTNAME = "dashboard_config.management_hostname";
     public static final String DASHBOARD_CONFIG_MANAGEMENT_PORT = "dashboard_config.management_port";
+    // Must be set to the same value as [mi_super_admin].password in the dashboard's deployment.toml. Registration
+    // now requires proving possession of that shared secret before the dashboard will register this node, so
+    // without it configured here the node can never get past a first-registration challenge.
+    public static final String DASHBOARD_CONFIG_ADMIN_PASSWORD = "dashboard_config.admin_password";
+
+    public static final String RESPONSE_FIELD_STATUS = "status";
+    public static final String RESPONSE_FIELD_CHALLENGE = "challenge";
+    public static final String REQUEST_FIELD_SIGNED_CHALLENGE = "signedChallenge";
+    public static final String STATUS_VALUE_CHALLENGE = "challenge";
+    public static final String STATUS_VALUE_SUCCESS = "success";
+    public static final String HMAC_ALGORITHM = "HmacSHA256";
 
     // New ICP Configuration
     public static final String ICP_API_DEFAULT_HOST = "localhost";

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
@@ -39,13 +39,21 @@ import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.core.util.StringUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.COLON;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.DASHBOARD_CONFIG_ADMIN_PASSWORD;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.DASHBOARD_CONFIG_GROUP_ID;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.DASHBOARD_CONFIG_HEARTBEAT_INTERVAL;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.DASHBOARD_CONFIG_NODE_ID;
@@ -53,10 +61,16 @@ import static org.wso2.micro.integrator.initializer.dashboard.Constants.DASHBOAR
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.DEFAULT_GROUP_ID;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.FORWARD_SLASH;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.HEADER_VALUE_APPLICATION_JSON;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.HMAC_ALGORITHM;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.HTTPS_PREFIX;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.MANAGEMENT;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.NODE_ID_SYSTEM_PROPERTY;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.PRODUCT_MI;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.REQUEST_FIELD_SIGNED_CHALLENGE;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.RESPONSE_FIELD_CHALLENGE;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.RESPONSE_FIELD_STATUS;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.STATUS_VALUE_CHALLENGE;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.STATUS_VALUE_SUCCESS;
 
 /**
  * Manages heartbeats from micro integrator to dashboard.
@@ -89,54 +103,131 @@ public class HeartBeatComponent {
         long interval = getInterval();
         String mgtApiUrl = getMgtApiUrl();
 
-        final HttpPost httpPost = new HttpPost(heartbeatApiUrl);
-
-        JsonObject heartbeatPayload = new JsonObject();
-        heartbeatPayload.addProperty("product", PRODUCT_MI);
-        heartbeatPayload.addProperty("groupId", groupId);
-        heartbeatPayload.addProperty("nodeId", nodeId);
-        heartbeatPayload.addProperty("interval", interval);
-        heartbeatPayload.addProperty("mgtApiUrl", mgtApiUrl);
-
-        httpPost.setHeader("Accept", HEADER_VALUE_APPLICATION_JSON);
-        httpPost.setHeader("Content-type", HEADER_VALUE_APPLICATION_JSON);
-
         ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
         Runnable runnableTask = () -> {
 
-            try (CloseableHttpClient client = HttpClients.custom().setSSLSocketFactory(
-                    new SSLConnectionSocketFactory(
-                            SSLContexts.custom().loadTrustMaterial(null,
-                                    (TrustStrategy) new TrustSelfSignedStrategy()).build(),
-                            NoopHostnameVerifier.INSTANCE)).build()) {
-                final StringEntity entity = new StringEntity(heartbeatPayload.toString());
-                httpPost.setEntity(entity);
-                CloseableHttpResponse response = client.execute(httpPost);
-                JsonObject jsonResponse = getJsonResponse(response);
-                if (jsonResponse != null && jsonResponse.get("status").getAsString().equals("success")) {
+            try {
+                JsonObject response = sendHeartbeat(
+                        heartbeatApiUrl, buildPayload(groupId, nodeId, interval, mgtApiUrl, null));
+                String status = getStatus(response);
+                if (STATUS_VALUE_SUCCESS.equals(status)) {
                     log.debug("Heartbeat sent successfully.");
-                    if (consecutiveFailureCount >= HEARTBEAT_WARN_THRESHOLD) {
-                        log.info("Heartbeat reporting to dashboard recovered after " + consecutiveFailureCount
-                                + " failed attempts.");
-                    }
-                    consecutiveFailureCount = 0;
+                    onHeartbeatOutcomeSuccess();
+                } else if (STATUS_VALUE_CHALLENGE.equals(status) && response.has(RESPONSE_FIELD_CHALLENGE)) {
+                    // First contact: the dashboard won't register this node - and hand it the mgtApiUrl-scoped
+                    // credential - until it's proven this node already holds the shared admin password.
+                    completeRegistration(heartbeatApiUrl, groupId, nodeId, interval, mgtApiUrl,
+                            response.get(RESPONSE_FIELD_CHALLENGE).getAsString());
                 } else {
                     log.debug("Error occurred while sending the heartbeat.");
                 }
             } catch (Exception e) {
                 log.debug("Error occurred while processing the heartbeat.", e);
-                consecutiveFailureCount++;
-                if (consecutiveFailureCount == HEARTBEAT_WARN_THRESHOLD) {
-                    log.warn("Heartbeat reporting to dashboard has failed " + consecutiveFailureCount
-                            + " consecutive times. Dashboard may be unreachable or misconfigured. "
-                            + "For further debugging, please refer debug logs.", e);
-                } else if (consecutiveFailureCount > HEARTBEAT_WARN_THRESHOLD) {
-                    log.warn("Error occurred while processing the heartbeat for " + consecutiveFailureCount
-                            + " consecutive times.", e);
-                }
+                onHeartbeatOutcomeFailure(e);
             }
         };
         scheduledExecutorService.scheduleAtFixedRate(runnableTask, 1, interval, TimeUnit.SECONDS);
+    }
+
+    private static void completeRegistration(String heartbeatApiUrl, String groupId, String nodeId, long interval,
+                                              String mgtApiUrl, String challenge) throws Exception {
+        String signedChallenge = signChallenge(challenge, groupId, nodeId, mgtApiUrl);
+        if (signedChallenge == null) {
+            log.warn("Cannot complete registration with the dashboard: " + DASHBOARD_CONFIG_ADMIN_PASSWORD
+                    + " is not configured, so the node registration challenge cannot be signed.");
+            return;
+        }
+        JsonObject response = sendHeartbeat(
+                heartbeatApiUrl, buildPayload(groupId, nodeId, interval, mgtApiUrl, signedChallenge));
+        if (STATUS_VALUE_SUCCESS.equals(getStatus(response))) {
+            log.debug("Node registered with the dashboard successfully.");
+            onHeartbeatOutcomeSuccess();
+        } else {
+            log.debug("Error occurred while completing node registration with the dashboard.");
+        }
+    }
+
+    private static void onHeartbeatOutcomeSuccess() {
+        if (consecutiveFailureCount >= HEARTBEAT_WARN_THRESHOLD) {
+            log.info("Heartbeat reporting to dashboard recovered after " + consecutiveFailureCount
+                    + " failed attempts.");
+        }
+        consecutiveFailureCount = 0;
+    }
+
+    private static void onHeartbeatOutcomeFailure(Exception e) {
+        consecutiveFailureCount++;
+        if (consecutiveFailureCount == HEARTBEAT_WARN_THRESHOLD) {
+            log.warn("Heartbeat reporting to dashboard has failed " + consecutiveFailureCount
+                    + " consecutive times. Dashboard may be unreachable or misconfigured. "
+                    + "For further debugging, please refer debug logs.", e);
+        } else if (consecutiveFailureCount > HEARTBEAT_WARN_THRESHOLD) {
+            log.warn("Error occurred while processing the heartbeat for " + consecutiveFailureCount
+                    + " consecutive times.", e);
+        }
+    }
+
+    private static String signChallenge(String challenge, String groupId, String nodeId, String mgtApiUrl) {
+        Object configuredPassword = configs.get(DASHBOARD_CONFIG_ADMIN_PASSWORD);
+        if (configuredPassword == null || StringUtils.isEmpty(configuredPassword.toString())) {
+            return null;
+        }
+        // Same canonicalization the dashboard verifies against: length-prefixed so that no rearrangement of
+        // these fields can be crafted to collide with a different, legitimately-signed combination.
+        String canonicalMessage = lengthPrefixed(challenge) + lengthPrefixed(groupId) + lengthPrefixed(nodeId)
+                + lengthPrefixed(mgtApiUrl == null ? "" : mgtApiUrl);
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(configuredPassword.toString().getBytes(StandardCharsets.UTF_8),
+                    HMAC_ALGORITHM));
+            byte[] signature = mac.doFinal(canonicalMessage.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(signature);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            log.debug("Error occurred while signing the node registration challenge.", e);
+            return null;
+        }
+    }
+
+    private static String lengthPrefixed(String value) {
+        return value.length() + COLON + value;
+    }
+
+    private static JsonObject buildPayload(String groupId, String nodeId, long interval, String mgtApiUrl,
+                                            String signedChallenge) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("product", PRODUCT_MI);
+        payload.addProperty("groupId", groupId);
+        payload.addProperty("nodeId", nodeId);
+        payload.addProperty("interval", interval);
+        payload.addProperty("mgtApiUrl", mgtApiUrl);
+        if (signedChallenge != null) {
+            payload.addProperty(REQUEST_FIELD_SIGNED_CHALLENGE, signedChallenge);
+        }
+        return payload;
+    }
+
+    private static String getStatus(JsonObject response) {
+        return response != null && response.has(RESPONSE_FIELD_STATUS)
+                ? response.get(RESPONSE_FIELD_STATUS).getAsString() : null;
+    }
+
+    /**
+     * Does not catch its own exceptions - callers rely on them propagating so consecutive-failure tracking
+     * (onHeartbeatOutcomeFailure) sees every network-level failure, matching this method's previous inline form.
+     */
+    private static JsonObject sendHeartbeat(String heartbeatApiUrl, JsonObject payload) throws Exception {
+        final HttpPost httpPost = new HttpPost(heartbeatApiUrl);
+        httpPost.setHeader("Accept", HEADER_VALUE_APPLICATION_JSON);
+        httpPost.setHeader("Content-type", HEADER_VALUE_APPLICATION_JSON);
+        try (CloseableHttpClient client = HttpClients.custom().setSSLSocketFactory(
+                new SSLConnectionSocketFactory(
+                        SSLContexts.custom().loadTrustMaterial(null,
+                                (TrustStrategy) new TrustSelfSignedStrategy()).build(),
+                        NoopHostnameVerifier.INSTANCE)).build()) {
+            httpPost.setEntity(new StringEntity(payload.toString()));
+            CloseableHttpResponse response = client.execute(httpPost);
+            return getJsonResponse(response);
+        }
     }
 
     private static String getMgtApiUrl() {


### PR DESCRIPTION
## Summary
Companion to a dashboard-side hardening of the node-registration heartbeat
handshake (wso2/integration-control-plane#823).

The legacy dashboard heartbeat client (used when `dashboard_config` is
configured, as opposed to the newer `icp_config`) now answers a
registration challenge from the dashboard instead of registering
unconditionally on first contact:

- On a heartbeat response with `status: "challenge"`, `HeartBeatComponent`
  signs `challenge|groupId|nodeId|mgtApiUrl` (length-prefixed,
  HMAC-SHA256, base64) using a new `dashboard_config.admin_password`
  config value, and resends the heartbeat with `signedChallenge` set - in
  the same tick, not waiting for the next interval.
- `dashboard_config.admin_password` must be set to the same value as the
  dashboard's `[mi_super_admin].password`. Without it configured, the node
  logs a warning and keeps retrying (a fresh challenge every tick) until
  it's set.
- The existing consecutive-failure warning threshold and the `icp_config`
  delegation path are untouched - this only changes the legacy
  `dashboard_config` first-contact registration behavior.
- Already-registered nodes are unaffected.

This is a breaking change for nodes still using `dashboard_config`: they
need this fix and `dashboard_config.admin_password` configured before
they can register against an updated dashboard.

## Test plan
- [x] `org.wso2.micro.integrator.initializer` builds clean (compiles and packages against `4.7.0-SNAPSHOT`)
- [x] Reviewed the signing canonicalization against the dashboard-side verifier - matches byte-for-byte
- [ ] Manual end-to-end registration handshake against the dashboard-side change