### PR TITLE
Fix service port parsing in MetricHandler

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/pom.xml
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/pom.xml
@@ -92,6 +92,11 @@
             <groupId>org.wso2.orbit.io.opentelemetry</groupId>
             <artifactId>opentelemetry-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.micro.integrator.observability.metric.handler;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.commons.lang3.StringUtils;
@@ -381,15 +383,25 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
         int invokePort = 0;
         if (null != ((Axis2MessageContext) synCtx).getAxis2MessageContext().
                 getProperty(NhttpConstants.SERVICE_PREFIX)) {
-            String servicePort = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
+            String servicePrefix = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
                     getProperty(NhttpConstants.SERVICE_PREFIX).toString();
-            servicePort = servicePort.substring(servicePort.lastIndexOf(':') + 1);
-            if (servicePort.contains(DELIMITER)) {
-                servicePort = servicePort.substring(0, servicePort.indexOf(DELIMITER));
-            }
-            invokePort = Integer.parseInt(servicePort);
+            invokePort = getServiceInvokePort(servicePrefix);
         }
         return invokePort;
+    }
+
+    /**
+     * Extract the port from a service prefix.
+     *
+     * @param servicePrefix the service prefix
+     * @return the port, or {@code -1} when it is absent or the prefix is invalid
+     */
+    static int getServiceInvokePort(String servicePrefix) {
+        try {
+            return new URI(servicePrefix).getPort();
+        } catch (URISyntaxException e) {
+            return -1;
+        }
     }
 
     /**

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/test/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandlerTest.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/test/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandlerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.integrator.observability.metric.handler;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for {@link MetricHandler}.
+ */
+public class MetricHandlerTest extends TestCase {
+
+    public void testGetServiceInvokePortWithExplicitPort() {
+        assertEquals(8290, MetricHandler.getServiceInvokePort("http://localhost:8290/services/"));
+    }
+
+    public void testGetServiceInvokePortWithoutExplicitPort() {
+        assertEquals(-1, MetricHandler.getServiceInvokePort("http://scanner.example/"));
+    }
+
+    public void testGetServiceInvokePortWithMalformedPrefix() {
+        assertEquals(-1, MetricHandler.getServiceInvokePort("not a valid URI"));
+    }
+
+    public void testGetServiceInvokePortWithHttpsPort() {
+        assertEquals(443, MetricHandler.getServiceInvokePort("https://example.com:443/"));
+    }
+
+    public void testGetServiceInvokePortWithIpv6Address() {
+        assertEquals(8290, MetricHandler.getServiceInvokePort("http://[2001:db8::1]:8290/api/v2/resource"));
+    }
+
+    public void testGetServiceInvokePortWithInvalidPort() {
+        assertEquals(-1, MetricHandler.getServiceInvokePort("http://localhost:not-a-port/api/v2/resource"));
+    }
+}


### PR DESCRIPTION
## Purpose

Prevent the observability metric handler from throwing `NumberFormatException` when the transport provides a `SERVICE_PREFIX` without an explicit numeric port.

Resolves #5025.

## Goals

- Keep request processing operational for portless or malformed service prefixes.
- Preserve explicit-port detection used to exclude the internal HTTP API from API metrics.
- Cover the regression and URI edge cases with focused unit tests.

## Approach

Replace manual colon and slash substring parsing with `java.net.URI#getPort()`. The standard parser returns `-1` when no explicit port is present. Syntactically invalid prefixes are handled defensively and also return `-1`, preventing observability code from failing request processing.

## User stories

As an MI operator, I want unexpected transport service-prefix values to be handled safely so that observability instrumentation cannot interrupt API requests.

## Release note

Fixed a `NumberFormatException` in the observability metric handler when processing a service prefix without an explicit port.

## Documentation

N/A. This is a defensive bug fix with no configuration or public API changes.

## Training

N/A. No training-content impact.

## Certification

N/A. No certification impact.

## Marketing

N/A. No marketing impact.

## Automation tests

- Unit tests
  - Added six focused cases covering HTTP and HTTPS explicit ports, a missing port, malformed input, IPv6, and a non-numeric port.
  - Result: 6 tests run, 0 failures, 0 errors, 0 skipped.
- Integration tests
  - N/A. The defect is isolated to deterministic service-prefix parsing.

## Security checks

- Followed secure coding standards: yes.
- Ran FindSecurityBugs plugin and verified report: no; this focused parsing change was validated with unit tests.
- Confirmed that this PR does not commit keys, passwords, tokens, usernames, or other secrets: yes.

## Samples

N/A. No sample changes are required.

## Related PRs

N/A.

## Migrations (if applicable)

N/A. No migration is required.

## Test environment

- Windows 11, amd64
- Eclipse Temurin OpenJDK 21.0.11
- Apache Maven 3.8.5
- Command: `mvn -B -f components/mediation/data-publishers/org.wso2.micro.integrator.observability/pom.xml -Dmaven.test.skip=false -DskipTests=false clean test`

## Learning

Used the JDK URI parser to avoid duplicating authority and IPv6 parsing logic. `URI#getPort()` provides the required `-1` sentinel for an absent or non-numeric port.