### PR TITLE
Fix ClassCastException in Service Catalog uploader when transport ports are unquoted in deployment.toml

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/serviceCatalog/ServiceCatalogDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/serviceCatalog/ServiceCatalogDeployer.java
@@ -55,48 +55,53 @@ public class ServiceCatalogDeployer implements Runnable {
 
     @Override
     public void run() {
-        if (isHotDeployment) {
-            log.info("Executing Service Catalog deployer for CApp : " + cAppName);
-        } else {
-            log.info("Executing Service Catalog deployer for all CApps at server startup");
+        try {
+            if (isHotDeployment) {
+                log.info("Executing Service Catalog deployer for CApp : " + cAppName);
+            } else {
+                log.info("Executing Service Catalog deployer for all CApps at server startup");
+            }
+
+            /*
+             * Check pre-conditions:
+             * Validates whether the environment is ready to start the service-catalog uploader.
+             *
+             * This method performs the following checks:
+             * - No faulty Carbon Applications (CAPPs) are present.
+             * - At least one Carbon Application is deployed.
+             * - At least one API or Proxy Service is deployed in the super tenant domain.
+             *
+             * If any of these conditions fail, it logs the reason and exits.
+             */
+            if (!checkPreConditions()) return;
+
+            // call service catalog and get all services
+            Map<String, String> md5MapOfAllService = getAllServices(serviceCatalogConfiguration);
+            if (md5MapOfAllService == null) return; // error occurred while getting all services
+
+            // create temporary directory to hold metadata.
+            if (!createTemporaryFolders(CAPP_UNZIP_DIR)) return;
+
+            File tempDir = new File(CAPP_UNZIP_DIR, TEMP_FOLDER_NAME);
+
+            // extract CAPPs and copy metadata to temp directory.
+            // The behavior differs in server startup mode and hot deployment mode.
+            boolean extractionSuccessful = isHotDeployment
+                    ? extractMetadataFromCAPP(cAppName, tempDir, repoLocation, md5MapOfAllService)
+                    : extractMetadataFromCAPPs(tempDir, repoLocation, md5MapOfAllService);
+
+            if (!extractionSuccessful) {
+                return;
+            }
+
+            // create the payload.zip file with extracted metadata
+            if (!archiveDir(CAPP_UNZIP_DIR + File.separator + ZIP_FOLDER_NAME, tempDir.getPath())) return;
+
+            // publish to service catalog endpoint.
+            publishToAPIM(serviceCatalogConfiguration, CAPP_UNZIP_DIR + File.separator + ZIP_FOLDER_NAME);
+        } catch (Exception e) {
+            // Uncaught exceptions on this executor thread would otherwise be silently lost (stderr only).
+            log.error("Error while executing Service Catalog deployer for CApp : " + cAppName, e);
         }
-
-        /*
-         * Check pre-conditions:
-         * Validates whether the environment is ready to start the service-catalog uploader.
-         *
-         * This method performs the following checks:
-         * - No faulty Carbon Applications (CAPPs) are present.
-         * - At least one Carbon Application is deployed.
-         * - At least one API or Proxy Service is deployed in the super tenant domain.
-         *
-         * If any of these conditions fail, it logs the reason and exits.
-         */
-        if (!checkPreConditions()) return;
-
-        // call service catalog and get all services
-        Map<String, String> md5MapOfAllService = getAllServices(serviceCatalogConfiguration);
-        if (md5MapOfAllService == null) return; // error occurred while getting all services
-
-        // create temporary directory to hold metadata.
-        if (!createTemporaryFolders(CAPP_UNZIP_DIR)) return;
-
-        File tempDir = new File(CAPP_UNZIP_DIR, TEMP_FOLDER_NAME);
-
-        // extract CAPPs and copy metadata to temp directory.
-        // The behavior differs in server startup mode and hot deployment mode.
-        boolean extractionSuccessful = isHotDeployment
-                ? extractMetadataFromCAPP(cAppName, tempDir, repoLocation, md5MapOfAllService)
-                : extractMetadataFromCAPPs(tempDir, repoLocation, md5MapOfAllService);
-
-        if (!extractionSuccessful) {
-            return;
-        }
-
-        // create the payload.zip file with extracted metadata
-        if (!archiveDir(CAPP_UNZIP_DIR + File.separator + ZIP_FOLDER_NAME, tempDir.getPath())) return;
-
-        // publish to service catalog endpoint.
-        publishToAPIM(serviceCatalogConfiguration, CAPP_UNZIP_DIR + File.separator + ZIP_FOLDER_NAME);
     }
 }

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/ServiceCatalogUtils.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/ServiceCatalogUtils.java
@@ -155,7 +155,7 @@ public class ServiceCatalogUtils {
                             httpsListenerPort = resolver.resolve();
                         } catch (ResolverException e) {
                             int portOffset = Integer.parseInt(System.getProperty(SERVER_PORT_OFFSET));
-                            int httpsPort = Integer.parseInt((String) parsedConfigs.get(HTTPS_LISTENER_PORT));
+                            int httpsPort = Integer.parseInt(String.valueOf(parsedConfigs.get(HTTPS_LISTENER_PORT)));
                             httpsListenerPort = String.valueOf(httpsPort + portOffset);
                         }
                     }
@@ -167,7 +167,7 @@ public class ServiceCatalogUtils {
                             httpListenerPort = resolver.resolve();
                         } catch (ResolverException e) {
                             int portOffset = Integer.parseInt(System.getProperty(SERVER_PORT_OFFSET));
-                            int httpsPort = Integer.parseInt((String) parsedConfigs.get(HTTP_LISTENER_PORT));
+                            int httpsPort = Integer.parseInt(String.valueOf(parsedConfigs.get(HTTP_LISTENER_PORT)));
                             httpListenerPort = String.valueOf(httpsPort + portOffset);
                         }
                     }


### PR DESCRIPTION
Unquoted port values in deployment.toml (e.g. `listener.port = 8290`) parse as Long, but updateServiceUrl() hard-cast them to String while resolving {MI_PORT}, killing the uploader thread with an uncaught ClassCastException and no trace in wso2carbon.log.

- Cast ports safely via String.valueOf(...) instead of (String).
- Wrap ServiceCatalogDeployer.run() in a try/catch so future failures actually get logged.

Fixes: https://github.com/wso2/product-integrator-mi/issues/5027