### PR TITLE
Fix service catalog startup check undercounting when embedded CARs are present

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -209,6 +209,12 @@ public class CappDeployer extends AbstractDeployer {
     private ExecutorService initialServiceCatalogExecutor;
 
     /**
+     * Cached total count of CApps in the initial startup deployment batch,
+     * accounting for both top-level .car files and any embedded CAR files inside them.
+     */
+    private int startupBatchSize = -1;
+
+    /**
      * Map object to store Service Catalog configuration
      */
     private Map serviceCatalogConfiguration;
@@ -389,7 +395,8 @@ public class CappDeployer extends AbstractDeployer {
             }
         }
 
-        boolean isAllCAppsDeployed = getCAppFileList().length == cAppMap.size() + faultyCapps.size();
+        int batchSize = getStartupBatchSize();
+        boolean isAllCAppsDeployed = batchSize > 0 && (cAppMap.size() + faultyCapps.size()) >= batchSize;
 
         // Initial execution of Service catalog Deployer at server startup when last CApp get deployed.
         // isServiceCatalogStartupExecutionPending guards against multiple submissions.
@@ -1383,16 +1390,71 @@ public class CappDeployer extends AbstractDeployer {
      * Retrieves a list of Carbon Application (CApp) files from the CApps directory.
      *
      * This method scans the CApps folder within the Carbon repository location
-     * and returns all files with the ".car" extension (Carbon Archive files).
+     * (or the configured CApp directory) and returns all files with the ".car"
+     * extension (Carbon Archive files).
      *
      * @return an array of File objects representing all .car files found in the
-     *         CApps directory.
+     *         CApps directory, or an empty array if none found or folder unreadable.
      */
     private File[] getCAppFileList() {
-        FilenameFilter CAPP_FILTER = (f, name) -> name.endsWith(".car");
+        FilenameFilter CAPP_FILTER = (f, name) -> name.endsWith(CAR_FILE_EXTENSION);
 
-        File cappFolder = new File(((CarbonAxisConfigurator) axisConfig.getAxisConfiguration().getConfigurator())
-                .getRepoLocation(), CAPP_FOLDER_NAME);
-        return cappFolder.listFiles(CAPP_FILTER);
+        File cappFolder = null;
+        if (axisConfig != null && axisConfig.getAxisConfiguration() != null &&
+                axisConfig.getAxisConfiguration().getConfigurator() != null) {
+            cappFolder = new File(((CarbonAxisConfigurator) axisConfig.getAxisConfiguration().getConfigurator())
+                    .getRepoLocation(), CAPP_FOLDER_NAME);
+        } else if (this.cAppDir != null) {
+            cappFolder = new File(this.cAppDir);
+        }
+        if (cappFolder == null || !cappFolder.exists() || !cappFolder.isDirectory()) {
+            return new File[0];
+        }
+        File[] files = cappFolder.listFiles(CAPP_FILTER);
+        return files != null ? files : new File[0];
+    }
+
+    /**
+     * Calculates the total number of CApps in the initial startup deployment batch,
+     * including both top-level .car files and any embedded CAR files contained within them.
+     *
+     * @return the total count of CApps to be deployed at startup
+     */
+    int getStartupBatchSize() {
+        if (startupBatchSize != -1) {
+            return startupBatchSize;
+        }
+        File[] topLevelFiles = getCAppFileList();
+        if (topLevelFiles.length == 0) {
+            startupBatchSize = 0;
+            return 0;
+        }
+        int totalCount = topLevelFiles.length;
+        for (File carFile : topLevelFiles) {
+            if (!carFile.isFile()) {
+                continue;
+            }
+            try (ZipFile zipFile = new ZipFile(carFile)) {
+                long embeddedCount = zipFile.stream()
+                        .filter(e -> !e.isDirectory())
+                        .filter(e -> e.getName().startsWith(AppDeployerUtils.DEPENDENCIES_DIR))
+                        .filter(e -> e.getName().toLowerCase(Locale.ROOT).endsWith(CAR_FILE_EXTENSION))
+                        .count();
+                totalCount += (int) embeddedCount;
+            } catch (Exception e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error inspecting CAR file for embedded dependencies: " + carFile.getName(), e);
+                }
+            }
+        }
+        startupBatchSize = totalCount;
+        return startupBatchSize;
+    }
+
+    /**
+     * Resets the cached startup batch size. Package-private for testing purposes.
+     */
+    void resetStartupBatchSize() {
+        this.startupBatchSize = -1;
     }
 }

--- a/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployerTest.java
+++ b/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployerTest.java
@@ -1590,4 +1590,57 @@ public class CappDeployerTest {
         assertEquals("b.car", files.get(1).getFile().getName());
         assertEquals("c.car", files.get(2).getFile().getName());
     }
+
+    // -------------------------------------------------------------------------
+    // Startup batch size tracking tests (Issue #4883)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testStartupBatchSize_EmptyDirectory() {
+        CappDeployer deployer = createDeployer();
+        assertEquals("Empty directory must yield 0 startup batch size", 0, deployer.getStartupBatchSize());
+    }
+
+    @Test
+    public void testStartupBatchSize_WithOnlyTopLevelCars() throws IOException {
+        createCarFile("app1.car", "synapse/api");
+        createCarFile("app2.car", "synapse/sequence");
+
+        CappDeployer deployer = createDeployer();
+        assertEquals("Startup batch size must match top-level CAR count when no embedded CARs exist",
+                2, deployer.getStartupBatchSize());
+    }
+
+    @Test
+    public void testStartupBatchSize_WithEmbeddedCars() throws Exception {
+        createCarFile("regular-app.car", "synapse/api");
+
+        File fatCar = DeployerUtilTest.createFatCarFile(tempCAppDir, "fat-parent.car", "nested-child.car",
+                "com.example", "fat-parent", "1.0.0",
+                "com.example", "nested-child", "1.0.0");
+        tempFiles.add(fatCar);
+
+        CappDeployer deployer = createDeployer();
+        // 2 top-level CARs (regular-app.car + fat-parent.car) + 1 embedded CAR (nested-child.car) = 3 total
+        assertEquals("Startup batch size must account for both top-level and embedded CARs",
+                3, deployer.getStartupBatchSize());
+    }
+
+    @Test
+    public void testStartupBatchSize_CachingAndReset() throws IOException {
+        createCarFile("app1.car", "synapse/api");
+
+        CappDeployer deployer = createDeployer();
+        assertEquals(1, deployer.getStartupBatchSize());
+
+        // Add another car file after initial computation
+        createCarFile("app2.car", "synapse/sequence");
+        // Cached value should remain 1
+        assertEquals("Batch size should be cached after first computation", 1, deployer.getStartupBatchSize());
+
+        // Reset cache
+        deployer.resetStartupBatchSize();
+        assertEquals("Batch size should be recomputed after reset", 2, deployer.getStartupBatchSize());
+    }
 }
+


### PR DESCRIPTION
### Purpose
Fixes #4883

### Description
In `CappDeployer#deployCarbonApplications`, the server startup completion check (`isAllCAppsDeployed`) compared `cAppMap.size() + faultyCapps.size()` against `getCAppFileList().length`. Because `getCAppFileList()` only counts top-level `.car` files on disk while `cAppMap` and `faultyCapps` include both top-level and embedded CAR deployments (introduced in #4871), the presence of embedded CARs caused the equality condition to be satisfied prematurely before remaining top-level startup CApps had finished deploying.

This PR introduces `getStartupBatchSize()` which calculates the full startup batch size by scanning top-level `.car` archives and any nested `.car` files under `dependencies/`, ensuring that the initial `ServiceCatalogDeployer` execution only triggers after all startup CApps have been deployed.

### Changes
- Added `startupBatchSize` field and `getStartupBatchSize()` method in `CappDeployer.java`.
- Updated `deployCarbonApplications()` to evaluate `isAllCAppsDeployed` against `getStartupBatchSize()`.
- Added unit tests in `CappDeployerTest.java` verifying startup batch size calculation with top-level and embedded CARs, caching, and cache reset.

### Test Environment
- Oracle JDK 22 / OpenJDK 11
- Apache Maven 3.9.14
- Windows 11
