### PR TITLE
Drop the delete barrier startup log line

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/standalone/ScheduledTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/standalone/ScheduledTaskManager.java
@@ -145,8 +145,6 @@ public class ScheduledTaskManager extends AbstractQuartzTaskManager {
         this.clusterCoordinator = DataHolder.getInstance().getClusterCoordinator();
         this.taskDeleteBarrierEnabled = TaskHandlingConfigUtils.isTaskDeleteBarrierEnabled();
         this.coordinationHardened = TaskHandlingConfigUtils.isCoordinationHardeningEnabled();
-        log.info("Clustered task delete barrier flow is " + (taskDeleteBarrierEnabled ? "enabled" : "disabled")
-                + ". Configure [" + TaskHandlingConfigUtils.TASK_DELETE_BARRIER_ENABLED_CONFIG + "] to control it.");
     }
 
     @Override


### PR DESCRIPTION


The INFO line in the ScheduledTaskManager constructor printed on every start, with or without coordination configured, including standalone nodes where the barrier flow can never apply. The barrier flow is enabled by default from 4.6.0 onwards, so there is no need to echo the setting at startup. Only the log line is removed. The setting is still read and applied on the clustered delete path.